### PR TITLE
docs: Updated torchcam import in quicktour

### DIFF
--- a/torch-cam/quicktour.ipynb
+++ b/torch-cam/quicktour.ipynb
@@ -183,7 +183,7 @@
         "from torchvision.models import resnet18\n",
         "from torchvision.transforms.functional import normalize, resize, to_pil_image\n",
         "\n",
-        "from torchcam.cams import SmoothGradCAMpp, LayerCAM\n",
+        "from torchcam.methods import SmoothGradCAMpp, LayerCAM\n",
         "from torchcam.utils import overlay_mask"
       ],
       "execution_count": 1,


### PR DESCRIPTION
This PR updates the import of `torchcam` in the quicktour