### PR TITLE
docs: Fixed legacy method call

### DIFF
--- a/torch-cam/quicktour.ipynb
+++ b/torch-cam/quicktour.ipynb
@@ -375,7 +375,7 @@
       },
       "source": [
         "# Once you're finished, clear the hooks on your model\n",
-        "cam_extractor.clear_hooks()"
+        "cam_extractor.remove_hooks()"
       ],
       "execution_count": 8,
       "outputs": []
@@ -488,7 +488,7 @@
       },
       "source": [
         "# Once you're finished, clear the hooks on your model\n",
-        "cam_extractor.clear_hooks()"
+        "cam_extractor.remove_hooks()"
       ],
       "execution_count": 12,
       "outputs": []
@@ -633,7 +633,7 @@
       },
       "source": [
         "# Once you're finished, clear the hooks on your model\n",
-        "cam_extractor.clear_hooks()"
+        "cam_extractor.remove_hooks()"
       ],
       "execution_count": 17,
       "outputs": []


### PR DESCRIPTION
This PR fixes a legacy call to clear_hooks which has been renamed to remove_hooks.

cf. https://github.com/frgfm/torch-cam/issues/155